### PR TITLE
PALLADIO-503 Remove old StoEx Parser/Serialise/Utilities

### DIFF
--- a/bundles/org.palladiosimulator.solver/src/org/palladiosimulator/solver/transformations/ExpressionToPDFWrapper.java
+++ b/bundles/org.palladiosimulator.solver/src/org/palladiosimulator/solver/transformations/ExpressionToPDFWrapper.java
@@ -4,6 +4,7 @@ import org.apache.log4j.Logger;
 import org.palladiosimulator.pcm.core.CoreFactory;
 import org.palladiosimulator.pcm.core.PCMRandomVariable;
 import org.palladiosimulator.pcm.seff.seff_performance.ParametricResourceDemand;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
 import org.palladiosimulator.solver.visitors.ExpressionHelper;
 
 import de.uka.ipd.sdq.probfunction.ProbabilityDensityFunction;
@@ -25,7 +26,6 @@ import de.uka.ipd.sdq.stoex.IntLiteral;
 import de.uka.ipd.sdq.stoex.NumericLiteral;
 import de.uka.ipd.sdq.stoex.ProbabilityFunctionLiteral;
 import de.uka.ipd.sdq.stoex.analyser.probfunction.ProbfunctionHelper;
-import de.uka.ipd.sdq.stoex.analyser.visitors.StoExPrettyPrintVisitor;
 
 /**
  * Wraps the actual content of an expression to allow computation with it. 
@@ -40,7 +40,8 @@ public class ExpressionToPDFWrapper {
 	Double standardDeviation;
 	boolean originalPDF;
 	
-	protected static Logger logger = Logger.getLogger("org.palladiosimulator.solver.transformations");
+	protected static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
+	protected static final Logger LOGGER = Logger.getLogger("org.palladiosimulator.solver.transformations");
 	
 	public ExpressionToPDFWrapper(ProbabilityDensityFunction pdf){
 		this.pdf = pdf;
@@ -80,8 +81,8 @@ public class ExpressionToPDFWrapper {
 					// try solving last, as this is probably most time-consuming. 
 					Expression solvedExpression = ExpressionHelper.getSolvedExpression(rdExpression, null);
 					// if the content of the Expression has been changed by solving, try again to call this method 
-					String oldExpressionString = new StoExPrettyPrintVisitor().doSwitch(rdExpression).toString();
-					solvedExprString = new StoExPrettyPrintVisitor().doSwitch(solvedExpression).toString();
+					String oldExpressionString = STOEX_SERIALISER.serialise(rdExpression);
+					solvedExprString = STOEX_SERIALISER.serialise(solvedExpression);
 					if (!oldExpressionString.equals(solvedExprString)){
 						return createExpressionToPDFWrapper(solvedExpression);
 					}
@@ -121,7 +122,7 @@ public class ExpressionToPDFWrapper {
 				ContextWrapper.logger.error("Error calculating arithmetic mean value.", e);
 				e.printStackTrace();
 			} catch (RuntimeException e){
-				logger.error("Could not get mean value of PDF "+pdf.toString());
+				LOGGER.error("Could not get mean value of PDF "+pdf.toString());
 				throw e;
 			}
 		}

--- a/bundles/org.palladiosimulator.solver/src/org/palladiosimulator/solver/transformations/pcm2lqn/UsageModel2Lqn.java
+++ b/bundles/org.palladiosimulator.solver/src/org/palladiosimulator/solver/transformations/pcm2lqn/UsageModel2Lqn.java
@@ -10,6 +10,7 @@ import org.palladiosimulator.pcm.repository.BasicComponent;
 import org.palladiosimulator.pcm.repository.RepositoryComponent;
 import org.palladiosimulator.pcm.seff.ResourceDemandingSEFF;
 import org.palladiosimulator.pcm.seff.ServiceEffectSpecification;
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
 import org.palladiosimulator.pcm.usagemodel.Branch;
 import org.palladiosimulator.pcm.usagemodel.BranchTransition;
 import org.palladiosimulator.pcm.usagemodel.ClosedWorkload;
@@ -57,8 +58,10 @@ public class UsageModel2Lqn extends UsagemodelSwitch<String> {
 
 	private static final String USAGE_DELAY = "USAGE_DELAY";
 
-	private static Logger logger = Logger.getLogger(UsageModel2Lqn.class
+	private static final Logger LOGGER = Logger.getLogger(UsageModel2Lqn.class
 			.getName());
+
+	private static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
 	
 	private int counter;
 
@@ -178,7 +181,7 @@ public class UsageModel2Lqn extends UsagemodelSwitch<String> {
 			DoubleLiteral doubleExp = (DoubleLiteral) exp;
 			result = doubleExp.getValue();
 		} else if(FunctionLiteral.class.isInstance(exp)) {
-			ExpressionSolveVisitor expressionSolveVisitor = new ExpressionSolveVisitor(ExpressionHelper.getTypeAnnotation(exp));
+			ExpressionSolveVisitor expressionSolveVisitor = new ExpressionSolveVisitor(ExpressionHelper.getTypeAnnotation(exp), STOEX_SERIALISER::serialise);
 			Expression resultExpression = (Expression) expressionSolveVisitor.doSwitch(exp);
 			if (ProbabilityFunctionLiteral.class.isInstance(resultExpression)){
 				ProbabilityFunctionLiteral propFunctionLiteral = (ProbabilityFunctionLiteral)resultExpression;
@@ -271,11 +274,11 @@ public class UsageModel2Lqn extends UsagemodelSwitch<String> {
 				entryId = (String) seffVisitor
 						.doSwitch((ResourceDemandingSEFF) seff);
 			} catch (RuntimeException e) {
-				logger.error("Error while visiting RDSEFF");
+				LOGGER.error("Error while visiting RDSEFF");
 				throw e;
 			}
 		} else {
-			logger.error("Composite Component type not yet supported.");
+			LOGGER.error("Composite Component type not yet supported.");
 			throw new UnsupportedOperationException();
 		}
 

--- a/bundles/org.palladiosimulator.solver/src/org/palladiosimulator/solver/utils/ManagedPMFParser.java
+++ b/bundles/org.palladiosimulator.solver/src/org/palladiosimulator/solver/utils/ManagedPMFParser.java
@@ -1,7 +1,8 @@
 package org.palladiosimulator.solver.utils;
 
+import java.text.ParseException;
+
 import org.palladiosimulator.pcm.stoex.api.StoExParser;
-import org.palladiosimulator.pcm.stoex.api.StoExParser.SyntaxErrorException;
 
 import de.uka.ipd.sdq.probfunction.ProbabilityMassFunction;
 import de.uka.ipd.sdq.probfunction.math.ManagedPMF;
@@ -32,7 +33,7 @@ public final class ManagedPMFParser {
         Expression parsedStoEx;
         try {
             parsedStoEx = STOEX_PARSER.parse(serializedStoEx);
-        } catch (SyntaxErrorException e) {
+        } catch (ParseException e) {
             throw new StringNotPMFException(e.getMessage());
         }
         if (!(parsedStoEx instanceof ProbabilityFunctionLiteral)) {

--- a/bundles/org.palladiosimulator.solver/src/org/palladiosimulator/solver/visitors/ExpressionHelper.java
+++ b/bundles/org.palladiosimulator.solver/src/org/palladiosimulator/solver/visitors/ExpressionHelper.java
@@ -1,5 +1,7 @@
 package org.palladiosimulator.solver.visitors;
 
+import java.io.NotSerializableException;
+import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -11,8 +13,6 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.palladiosimulator.pcm.core.PCMRandomVariable;
 import org.palladiosimulator.pcm.stoex.api.StoExParser;
 import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
-import org.palladiosimulator.pcm.stoex.api.StoExParser.SyntaxErrorException;
-import org.palladiosimulator.pcm.stoex.api.StoExSerialiser.SerialisationErrorException;
 import org.palladiosimulator.solver.transformations.ContextWrapper;
 import org.palladiosimulator.solver.transformations.ExpressionToPDFWrapper;
 
@@ -36,7 +36,7 @@ public class ExpressionHelper {
 		Expression expression = null;
 		try {
 			expression = STOEX_PARSER.parse(specification);
-		} catch (SyntaxErrorException e) {
+		} catch (ParseException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
@@ -48,7 +48,7 @@ public class ExpressionHelper {
         try {
             Expression typedExpression = transformExpressionToTypedExpression(solvedExpression);
             return STOEX_SERIALISER.serialise(typedExpression);
-        } catch (SerialisationErrorException e) {
+        } catch (NotSerializableException e) {
             throw new RuntimeException("Could not print solved expression " + specification, e);
         }
     }

--- a/bundles/org.palladiosimulator.solver/src/org/palladiosimulator/solver/visitors/ExpressionParameterSolverVisitor.java
+++ b/bundles/org.palladiosimulator.solver/src/org/palladiosimulator/solver/visitors/ExpressionParameterSolverVisitor.java
@@ -3,13 +3,12 @@ package org.palladiosimulator.solver.visitors;
 
 import java.util.HashMap;
 
-import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
 import org.palladiosimulator.pcm.parameter.CharacterisedVariable;
 import org.palladiosimulator.pcm.parameter.VariableCharacterisation;
 import org.palladiosimulator.pcm.parameter.VariableUsage;
-
+import org.palladiosimulator.pcm.stoex.api.StoExSerialiser;
 import org.palladiosimulator.solver.context.computed_usage.ExternalCallOutput;
 import org.palladiosimulator.solver.context.computed_usage.Input;
 import org.palladiosimulator.solver.transformations.ContextWrapper;
@@ -23,14 +22,13 @@ import de.uka.ipd.sdq.stoex.analyser.visitors.TypeEnum;
 
 public class ExpressionParameterSolverVisitor extends ExpressionSolveVisitor {
 
-	private static Logger logger = Logger
-	.getLogger(ExpressionParameterSolverVisitor.class.getName());
+    private static final StoExSerialiser STOEX_SERIALISER = StoExSerialiser.createInstance();
 
 	//private Context context;
 	private ContextWrapper contextWrapper;
 	
 	public ExpressionParameterSolverVisitor(HashMap<Expression, TypeEnum> typeAnn, ContextWrapper ctxWrp){
-		super(typeAnn);
+		super(typeAnn, STOEX_SERIALISER::serialise);
 		this.contextWrapper = ctxWrp;
 	}
 


### PR DESCRIPTION
As requested by [PALLADIO-503](https://palladio-simulator.atlassian.net/browse/PALLADIO-503), I removed the hand-written StoEx parsers, serialisers and utilities and adjusted the code that used these classes.

This PR requires PalladioSimulator/Palladio-Core-PCM#31 to be merged before it compiles.